### PR TITLE
Add python 3.6 to setup file classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
 ]
 INSTALL_REQUIRES = [
     'numpy',


### PR DESCRIPTION
Trying to accommodate for the following error.  Maybe there is a version specification somewhere else?
![image](https://user-images.githubusercontent.com/7726565/38103641-2b5f7e72-3344-11e8-86cf-97f100794957.png)
Sorry if this isn't up to the guidelines. I am still an amateur at merging changes.